### PR TITLE
Fix 'test is not defined' error in non-JSON file parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -7048,11 +7048,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/appium-geckodriver/node_modules/@types/semver": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
-      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "node_modules/appium-geckodriver/node_modules/@types/send": {
       "version": "0.17.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,11 +215,14 @@ function parseTests(config, files) {
           }
           // The `test` has the `setup` property, add `tests[0].steps` of setup to the beginning of the object's `steps` array.
           if (statementJson.setup) {
-            const setupContent = fs
-              .readFileSync(statementJson.setup)
-              .toString();
+            // Load setup steps
+            const setupContent = fs.readFileSync(statementJson.setup).toString();
             const setup = JSON.parse(setupContent);
-            statementJson.steps = setup.tests[0].steps.concat(test.steps);
+            if (setup && setup.tests && setup.tests[0] && setup.tests[0].steps) {
+              statementJson.steps = setup.tests[0].steps.concat(statementJson.steps);
+            } else {
+              console.error("Setup file does not contain valid steps.");
+            }
           }
           // Push to spec
           spec.tests.push(statementJson);


### PR DESCRIPTION
This PR resolves an issue with inline tests that included `setup` in the start statement. The bug manifested as a `ReferenceError: test is not defined` error. The root cause was an incorrect reference to a `test` variable in contexts where it hadn't been defined.

```
[comment]: # (test start {"id":"search-kittens", "setup": "setup-tests/cloud/cloud-log-in.json"})
```

