### PR TITLE
Capture groups for detected steps

### DIFF
--- a/dev/doc-content copy.md
+++ b/dev/doc-content copy.md
@@ -1,9 +1,9 @@
 # Doc Detective documentation overview
 
-[Doc Detective documentation](/) is split into a few key sections:
+[Doc Detective documentation](https://doc-detective.com) is split into a few key sections:
 
--   The landing page discusses what Doc Detective is, what it does, and who might find it useful.
--   [Get started](/get-started.html) covers how to quickly get up and running with Doc Detective.
--   The [references](/reference/) detail the various JSON objects that Doc Detective expects for [configs](/reference/schemas/config.html), [test specifications](/reference/schemas/specification.html), [tests](/reference/schemas/test), actions, and more. Open [typeKeys](/reference/schemas/typeKeys.html)--or any other schema--and you'll find three sections: **Description**, **Fields**, and **Examples**.
+- The landing page discusses what Doc Detective is, what it does, and who might find it useful.
+- [Get started](https://doc-detective.com/get-started.html) covers how to quickly get up and running with Doc Detective.
+- The [references](https://doc-detective.com/reference/) detail the various JSON objects that Doc Detective expects for [configs](https://doc-detective.com/reference/schemas/config.html), [test specifications](https://doc-detective.com/reference/schemas/specification.html), [tests](https://doc-detective.com/reference/schemas/test), actions, and more. Open [typeKeys](https://doc-detective.com/reference/schemas/typeKeys.html)--or any other schema--and you'll find three sections: **Description**, **Fields**, and **Examples**.
 
-![](reference.png)
+![Search results.](reference.png)

--- a/dev/index.js
+++ b/dev/index.js
@@ -85,9 +85,7 @@ async function main() {
           },
           {
             name: "Navigation link",
-            regex: [
-              "(?<=([Oo]pen|[Cc]lick) (?<!!)\\[[\\w\\s]+\\]\\().*?(?=\\))",
-            ],
+            regex: ["(?:[Oo]pen|[Cc]lick)\\s+\\[.+?\\]\\((.*?)\\)"],
             actions: ["goTo"],
           },
           {
@@ -100,12 +98,10 @@ async function main() {
             regex: ["(?<=\\!\\[.*?\\]\\().*?(?=\\))"],
             actions: [
               {
-                name: "saveScreenshot",
-                params: {
-                  directory: ".",
-                  maxVariation: 5,
-                  overwrite: "byVariation",
-                },
+                action: "saveScreenshot",
+                directory: ".",
+                maxVariation: 5,
+                overwrite: "byVariation",
               },
             ],
           },

--- a/dev/index.js
+++ b/dev/index.js
@@ -27,29 +27,43 @@ main();
 
 async function main() {
   json = {
-    envVariables: "",
+    envVariables: "./variables.env",
     input: ".",
     output: ".",
     recursive: true,
     logLevel: "debug",
     runTests: {
-      input: "dev/dev.spec.json",
+      detectSteps: true,
+      input: "./dev/doc-content copy.md",
       output: ".",
       setup: "",
       cleanup: "",
       recursive: true,
       mediaDirectory: ".",
       downloadDirectory: ".",
+      contexts: [
+        {
+          app: {
+            name: "firefox",
+            options: {
+              width: 1200,
+              height: 800,
+              headless: false,
+            },
+          },
+          platforms: ["linux", "mac", "windows"],
+        },
+      ],
     },
     runCoverage: {
       recursive: true,
-      input: "test/artifacts/",
+      input: ".",
       output: ".",
       markup: [],
     },
     suggestTests: {
       recursive: true,
-      input: "test/artifacts/doc-content-uncovered.md",
+      input: ".",
       output: ".",
       markup: [],
     },
@@ -66,15 +80,20 @@ async function main() {
         markup: [
           {
             name: "Hyperlink",
-            regex: ["(?<=(?<!!)\\[.*?\\]\\().*?(?=\\))"],
-            actions: [
-              {
-                name: "checkLink",
-                params: {
-                  origin: "https://doc-detective.com",
-                },
-              },
+            regex: ["(?<=(?<!!)\\[[\\w\\s]+\\]\\().*?(?=\\))"],
+            actions: ["checkLink"],
+          },
+          {
+            name: "Navigation link",
+            regex: [
+              "(?<=([Oo]pen|[Cc]lick) (?<!!)\\[[\\w\\s]+\\]\\().*?(?=\\))",
             ],
+            actions: ["goTo"],
+          },
+          {
+            name: "Onscreen text",
+            regex: ["(?<=\\*\\*)[\\w\\s]+?(?=\\*\\*)"],
+            actions: ["find"],
           },
           {
             name: "Image",
@@ -83,37 +102,20 @@ async function main() {
               {
                 name: "saveScreenshot",
                 params: {
-                  directory: "dev",
+                  directory: ".",
                   maxVariation: 5,
                   overwrite: "byVariation",
-                }
-              },
-            ],
-          },
-          {
-            name: "Navigation link",
-            regex: ["(?<=([Oo]pen|[Cc]lick) (?<!!)\\[[\\w\\s]*\\]\\().*?(?=\\))"],
-            actions: [
-              {
-                name: "goTo",
-                params: {
-                  origin: "https://doc-detective.com",
                 },
               },
             ],
-          },
-          {
-            name: "Onscreen text",
-            regex: ["(?<=\\*\\*)[\\w|\\s]+?(?=\\*\\*)"],
-            actions: ["find"],
           },
         ],
       },
     ],
     integrations: {},
     telemetry: {
-      send: false,
-      userId: "Doc Detective",
+      send: true,
+      userId: "Doc Detective Samples",
     },
   };
   // console.log(json);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.3",
         "appium-safari-driver": "^3.5.12",
         "axios": "^1.6.8",
-        "doc-detective-common": "^1.15.0",
+        "doc-detective-common": "1.16.0-rc.1",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.4.0",
         "geckodriver": "^4.4.0",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.5.4",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.5.4.tgz",
-      "integrity": "sha512-o2fsypTGU0WxRxbax8zQoHiIB4dyrkwYfcm8TxZ+bx9pCzcWZbQtiMqpgBvWA/nJ2TrGjK5adCLfTH8wUeU/Wg==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.1.tgz",
+      "integrity": "sha512-DxjgKBCoyReu4p5HMvpmgSOfRhhBcuf5V5soDDRgOTZMwsA4KSFzol1abFZgiCTE11L2kKGca5Md9GwDdXVBwQ==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",
@@ -14038,12 +14038,12 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.15.0.tgz",
-      "integrity": "sha512-MxsgZev65wWRYEB3sgGISmDmOlf5MYzxoli3b8CAbAl2QlFRNlzBG6mwOpVVjXKkEg37XIhgrYqfbhMFEIVd2w==",
+      "version": "1.16.0-rc.1",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.16.0-rc.1.tgz",
+      "integrity": "sha512-ivYpXhoiC9rnspmyK9hamjRIAbjZf5sCZEbxQY+X5tIBehoUM/U0s1FR6gFniXfIF8XPOAcSrS5QPZCSjzW2Mw==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.5.4",
-        "ajv": "^8.12.0",
+        "@apidevtools/json-schema-ref-parser": "^11.6.1",
+        "ajv": "8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
         "ajv-keywords": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.3",
     "appium-safari-driver": "^3.5.12",
     "axios": "^1.6.8",
-    "doc-detective-common": "^1.15.0",
+    "doc-detective-common": "1.16.0-rc.1",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.4.0",
     "geckodriver": "^4.4.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -359,7 +359,11 @@ function parseTests(config, files) {
           fileType.markup.forEach((markup) => {
             // Test for markup
             regex = new RegExp(markup.regex, "g");
-            matches = line.match(regex);
+            const matches = [];
+            markup.regex.forEach((regex) => {
+              const match = line.match(regex);
+              if (match) matches.push(...match);
+            });
             if (!matches) return false;
             action = markup.actions[0];
             log(config, "debug", `markup: ${markup.name}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -362,12 +362,11 @@ function parseTests(config, files) {
             regex = new RegExp(markup.regex, "g");
             const matches = [];
             markup.regex.forEach((regex) => {
-              const match = line.match(regex);
-              if (match) matches.push(match);
+              const match = line.matchAll(regex);
+              if (match) matches.push(...match);
             });
             // If no matches, skip
-            if (!matches) return false;
-
+            if (matches.length === 0) return false;
             log(config, "debug", `markup: ${markup.name}`);
 
             const actionMap = {
@@ -415,7 +414,7 @@ function parseTests(config, files) {
               markup.actions.forEach((action) => {
                 let step = {};
                 if (typeof action === "string") {
-                  step = actionMap[action];
+                  step = JSON.parse(JSON.stringify(actionMap[action]));
                 } else if (action.name) {
                   // TODO v3: Remove this block
                   if (action.params) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -429,13 +429,11 @@ function parseTests(config, files) {
                 step.index = match.index;
                 // Substitute variables $n with match[n]
                 Object.keys(step).forEach((key) => {
+                  if (typeof step[key] !== "string") return;
                   // Replace $n with match[n]
-                  step[key] = step[key].replace(/\$[0-9]+/g, (match) => {
-                    //  Replace $n with match[n]
-                    return match.replace(/\$([0-9]+)/, (match, number) => {
-                      // If match is a number, return match[number]
-                      return match.replace(match, match[number]);
-                    });
+                  step[key] = step[key].replace(/\$[0-9]+/g, (stepMatch) => {
+                    const index = stepMatch.substring(1);
+                    return match[index];
                   });
                 });
 


### PR DESCRIPTION
Standardizes regex behavior for detecting markup between `runTests` and `runCoverage` actions by matching the whole match AND capture groups, and mapping them to numbered variables in defined steps.

Also allows for defining markup actions as whole sequences of stanard step definitions rather than vaguely structure constructions.