### PR TITLE
v2.12.0

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -80,22 +80,24 @@ async function main() {
         markup: [
           {
             name: "Hyperlink",
-            regex: ["(?<=(?<!!)\\[[\\w\\s]+\\]\\().*?(?=\\))"],
+            regex: ["(?<!!)\\[.+?\\]\\(.+?\\)"],
             actions: ["checkLink"],
           },
           {
             name: "Navigation link",
-            regex: ["(?:[Oo]pen|[Cc]lick)\\s+\\[.+?\\]\\((.*?)\\)"],
+            regex: [
+              "(?:[Cc]hose|[Oo]pen|[Cc]lick|[Nn]avigate to|[Gg]o to)(?<!!)\\[.+?\\]\\(.+?\\)",
+            ],
             actions: ["goTo"],
           },
           {
             name: "Onscreen text",
-            regex: ["(?<=\\*\\*)[\\w\\s]+?(?=\\*\\*)"],
+            regex: ["\\*\\*.+?\\*\\*"],
             actions: ["find"],
           },
           {
             name: "Image",
-            regex: ["(?<=\\!\\[.*?\\]\\().*?(?=\\))"],
+            regex: ["!\\[.+?\\]\\(.+?\\)"],
             actions: [
               {
                 action: "saveScreenshot",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0-rc.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.12.0-rc.0",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.3",
         "appium-safari-driver": "^3.5.12",
         "axios": "^1.6.8",
-        "doc-detective-common": "1.16.0-rc.1",
+        "doc-detective-common": "1.16.0",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.4.0",
         "geckodriver": "^4.4.0",
@@ -14038,9 +14038,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.16.0-rc.1",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.16.0-rc.1.tgz",
-      "integrity": "sha512-ivYpXhoiC9rnspmyK9hamjRIAbjZf5sCZEbxQY+X5tIBehoUM/U0s1FR6gFniXfIF8XPOAcSrS5QPZCSjzW2Mw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.16.0.tgz",
+      "integrity": "sha512-Y/wcdU/yh1chVXisfs1RU+0IV/25D31XVZ+8x3QwBtBzirtR/sspi2nwii3+YUO77j2ZmN8uhTCxxXeHQIKd2g==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.1",
         "ajv": "8.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0-dev.125",
+  "version": "2.11.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.12.0-dev.125",
+      "version": "2.11.3-rc.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
-        "@puppeteer/browsers": "^2.2.2",
+        "@puppeteer/browsers": "^2.2.3",
         "appium": "^2.5.4",
         "appium-chromium-driver": "1.3.24",
         "appium-geckodriver": "^1.3.3",
@@ -24,7 +24,7 @@
         "node-jq": "^4.3.1",
         "pixelmatch": "^5.3.0",
         "pngjs": "^7.0.0",
-        "posthog-node": "^4.0.0",
+        "posthog-node": "^4.0.1",
         "prompt-sync": "^4.2.0",
         "tree-kill": "^1.2.2",
         "uuid": "^9.0.1",
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
-      "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.3.tgz",
+      "integrity": "sha512-bJ0UBsk0ESOs6RFcLXOt99a3yTDcOKlzfjad+rhFwdaG1Lu/Wzq58GHYCDTlZ9z6mldf4g+NTb+TXEfe0PpnsQ==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -17495,9 +17495,9 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.0.0.tgz",
-      "integrity": "sha512-jEZnNbgb/3FNk+gNwtTcyz3j+62zIN+UTPotONfacVXJnoI70KScSkKdIR+rvP9tA2kjBSoHQxGwJuizs27o9A==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-4.0.1.tgz",
+      "integrity": "sha512-rtqm2h22QxLGBrW2bLYzbRhliIrqgZ0k+gF0LkQ1SNdeD06YE5eilV0MxZppFSxC8TfH0+B0cWCuebEnreIDgQ==",
       "dependencies": {
         "axios": "^1.6.2",
         "rusha": "^0.8.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.3",
         "appium-safari-driver": "^3.5.12",
         "axios": "^1.6.8",
-        "doc-detective-common": "1.16.0",
+        "doc-detective-common": "^1.16.0",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.4.0",
         "geckodriver": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3-rc.4",
+  "version": "2.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.11.3-rc.4",
+      "version": "2.11.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3-rc.1",
+  "version": "2.11.3-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.11.3-rc.1",
+      "version": "2.11.3-rc.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,8 +19,8 @@
         "axios": "^1.6.8",
         "doc-detective-common": "^1.15.0",
         "dotenv": "^16.4.5",
-        "edgedriver": "^5.3.10",
-        "geckodriver": "^4.3.3",
+        "edgedriver": "^5.4.0",
+        "geckodriver": "^4.4.0",
         "node-jq": "^4.3.1",
         "pixelmatch": "^5.3.0",
         "pngjs": "^7.0.0",
@@ -12757,18 +12757,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -12916,22 +12904,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "engines": {
-        "node": ">=0.2.0"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -13025,17 +12997,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -14294,16 +14255,16 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.3.10.tgz",
-      "integrity": "sha512-RFSHYMNtcF1PjaGZCA2rdQQ8hSTLPZgcYgeY1V6dC+tR4NhZXwFAku+8hCbRYh7ZlwKKrTbVu9FwknjFddIuuw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.4.0.tgz",
+      "integrity": "sha512-5gA79cSdvB/wucK809OTxKP3hsVyXVROE8DL9vFiReYbknghadioV5pFXRr2kA4MZKJMKNsNCsInmaLeyCf03A==",
       "hasInstallScript": true,
       "dependencies": {
         "@wdio/logger": "^8.28.0",
         "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
         "node-fetch": "^3.3.2",
-        "unzipper": "^0.10.14",
+        "unzipper": "^0.11.4",
         "which": "^4.0.0"
       },
       "bin": {
@@ -15060,9 +15021,9 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.3.3.tgz",
-      "integrity": "sha512-we2c2COgxFkLVuoknJNx+ioP+7VDq0sr6SCqWHTzlA4kzIbzR0EQ1Pps34s8WrsOnQqPC8a4sZV9dRPROOrkSg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.4.0.tgz",
+      "integrity": "sha512-Y/Np2VkAhBkJoFAIY3pKH3rICUcR5rH9VD6EHwh0CqUIh6Opzr/NFwfcQenYfbRT/659R15/35LpA1s6h9wPPg==",
       "hasInstallScript": true,
       "dependencies": {
         "@wdio/logger": "^8.28.0",
@@ -15070,8 +15031,8 @@
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.4",
         "node-fetch": "^3.3.2",
-        "tar-fs": "^3.0.5",
-        "unzipper": "^0.10.14",
+        "tar-fs": "^3.0.6",
+        "unzipper": "^0.11.4",
         "which": "^4.0.0"
       },
       "bin": {
@@ -15082,9 +15043,9 @@
       }
     },
     "node_modules/geckodriver/node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -16127,11 +16088,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
     },
     "node_modules/locate-app": {
       "version": "2.4.8",
@@ -18362,11 +18318,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -19043,14 +18994,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -19209,53 +19152,21 @@
       }
     },
     "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.11.4.tgz",
+      "integrity": "sha512-T6CZQdmCMhlpHM+x4E5E9pIYCXH5INcrI8Cowr4tLQIciuw5nnp+X/LEwgeuFnay3vp9hVo4ydPw3WYSg2agWQ==",
       "dependencies": {
         "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
         "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
         "duplexer2": "~0.1.4",
         "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
+        "graceful-fs": "^4.2.2"
       }
     },
     "node_modules/unzipper/node_modules/bluebird": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/unzipper/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/unzipper/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3",
+  "version": "2.12.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.11.3",
+      "version": "2.12.0-rc.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3-rc.4",
+  "version": "2.11.3",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.3",
     "appium-safari-driver": "^3.5.12",
     "axios": "^1.6.8",
-    "doc-detective-common": "1.16.0",
+    "doc-detective-common": "^1.16.0",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.4.0",
     "geckodriver": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3-rc.1",
+  "version": "2.11.3-rc.4",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {
@@ -36,8 +36,8 @@
     "axios": "^1.6.8",
     "doc-detective-common": "^1.15.0",
     "dotenv": "^16.4.5",
-    "edgedriver": "^5.3.10",
-    "geckodriver": "^4.3.3",
+    "edgedriver": "^5.4.0",
+    "geckodriver": "^4.4.0",
     "node-jq": "^4.3.1",
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0-dev.125",
+  "version": "2.11.3-rc.1",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/doc-detective/doc-detective-core#readme",
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
-    "@puppeteer/browsers": "^2.2.2",
+    "@puppeteer/browsers": "^2.2.3",
     "appium": "^2.5.4",
     "appium-chromium-driver": "1.3.24",
     "appium-geckodriver": "^1.3.3",
@@ -41,7 +41,7 @@
     "node-jq": "^4.3.1",
     "pixelmatch": "^5.3.0",
     "pngjs": "^7.0.0",
-    "posthog-node": "^4.0.0",
+    "posthog-node": "^4.0.1",
     "prompt-sync": "^4.2.0",
     "tree-kill": "^1.2.2",
     "uuid": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.11.3",
+  "version": "2.12.0-rc.0",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0-rc.0",
+  "version": "2.12.0",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.3",
     "appium-safari-driver": "^3.5.12",
     "axios": "^1.6.8",
-    "doc-detective-common": "1.16.0-rc.1",
+    "doc-detective-common": "1.16.0",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.4.0",
     "geckodriver": "^4.4.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -105,20 +105,19 @@ async function installBrowsers() {
 
 // Run `appium` to install the Gecko driver, Chromium driver, and image plugin.
 async function installAppiumDepencencies() {
+  // Move to doc-detective-core directory to correctly set browser snapshot directory
+  cwd = process.cwd();
+  process.chdir(path.join(__dirname, ".."));
   // Install appium dependencies
   try {
     console.log("Installing Chrome/Edge driver");
-    chromiumInstall = await spawnCommand(
-      `npx appium driver install chromium`
-    );
+    chromiumInstall = await spawnCommand(`npx appium driver install chromium`);
   } catch (e) {
     console.log("Chrome/Edge driver not available.");
   }
   try {
     console.log("Installing Firefox driver");
-    geckoInstall = await spawnCommand(
-      `npx appium driver install gecko`
-    );
+    geckoInstall = await spawnCommand(`npx appium driver install gecko`);
   } catch (e) {
     console.log("Firefox driver not available.");
   }
@@ -126,11 +125,11 @@ async function installAppiumDepencencies() {
   if (process.platform == "darwin") {
     try {
       console.log("Installing Safari driver");
-      safariInstall = await spawnCommand(
-        `npx appium driver install safari`
-      );
+      safariInstall = await spawnCommand(`npx appium driver install safari`);
     } catch (e) {
       console.log("Safari driver not available.");
     }
   }
+  // Move back to original directory
+  process.chdir(cwd);
 }

--- a/src/tests.js
+++ b/src/tests.js
@@ -242,7 +242,7 @@ async function runSpecs(config, specs) {
   // Warm up Appium
   if (appiumRequired) {
     // Start Appium server
-    appium = spawn("npx", ["appium"], { shell: true, windowsHide: true});
+    appium = spawn("npx", ["appium"], { shell: true, windowsHide: true, cwd: path.join(__dirname, "..")});
     appium.stdout.on("data", (data) => {
       //   console.log(`stdout: ${data}`);
     });

--- a/src/tests.js
+++ b/src/tests.js
@@ -182,9 +182,9 @@ function getDefaultContexts(config) {
     });
   }
   // If no contexts are defined in config, or if none are supported, use fallback strategy
-  // Select the first available app, in the following order: Firefox, Chrome, Safari, Edge
+  // Select the first available app
   if (contexts.length === 0) {
-    const fallback = ["firefox", "chrome", "safari", "edge"];
+    const fallback = ["chrome", "firefox", "safari", "edge"];
     for (const browser of fallback) {
       if (contexts.length != 0) continue;
       const app = apps.find((app) => app.name === browser);


### PR DESCRIPTION
- Fetch input tests from URLs
- Added support for using capture groups in markup regex and specifying markup actions with full step definitions instead of piecemeal param overlays. 
- Updated default Markdown regexes to use capture groups.