### PR TITLE
v2.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.3",
         "appium-safari-driver": "^3.5.12",
         "axios": "^1.6.8",
-        "doc-detective-common": "^1.16.0",
+        "doc-detective-common": "^1.16.1",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.4.0",
         "geckodriver": "^4.4.0",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.1.tgz",
-      "integrity": "sha512-DxjgKBCoyReu4p5HMvpmgSOfRhhBcuf5V5soDDRgOTZMwsA4KSFzol1abFZgiCTE11L2kKGca5Md9GwDdXVBwQ==",
+      "version": "11.6.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.6.4.tgz",
+      "integrity": "sha512-9K6xOqeevacvweLGik6LnZCb1fBtCOSIWQs8d096XGeqoLKC33UVMGz9+77Gw44KvbH4pKcQPWo4ZpxkXYj05w==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.15",
@@ -14038,11 +14038,11 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.16.0.tgz",
-      "integrity": "sha512-Y/wcdU/yh1chVXisfs1RU+0IV/25D31XVZ+8x3QwBtBzirtR/sspi2nwii3+YUO77j2ZmN8uhTCxxXeHQIKd2g==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.16.1.tgz",
+      "integrity": "sha512-wOQn4UnhxequXIhT1LBBkEQtAFQiUI9ie9zJB+ap20h9Jv4WUOFdNCDkSjFAEM+/HVyU0J+48A0JVvbvtlOM1g==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^11.6.1",
+        "@apidevtools/json-schema-ref-parser": "^11.6.3",
         "ajv": "8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.0",
+  "version": "2.12.1-dev.0",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.12.1-dev.0",
+  "version": "2.12.1",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.3",
     "appium-safari-driver": "^3.5.12",
     "axios": "^1.6.8",
-    "doc-detective-common": "^1.16.0",
+    "doc-detective-common": "^1.16.1",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.4.0",
     "geckodriver": "^4.4.0",

--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -231,7 +231,7 @@ function objectExistsInObject(expected, actual) {
         if (result.result.description != "")
           description = description + " " + result.result.description;
       }
-    } else if (expected[key] != actual[key]) {
+    } else if (expected[key] !== actual[key]) {
       // Actual value doesn't match expected
       description =
         description +


### PR DESCRIPTION
- Set httpRequest response value checking to do literal type matching instead of fuzzy type matching.
- Deprecated the non-functional httpRequest responseParams attribute.