### PR TITLE
matchText regex support

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -33,7 +33,7 @@ async function main() {
     recursive: true,
     logLevel: "debug",
     runTests: {
-      input: "./test/artifacts/context_edge.spec.json",
+      input: "./test/artifacts/matchText_regex.spec.json",
       output: ".",
       setup: "",
       cleanup: "",
@@ -48,10 +48,6 @@ async function main() {
         },
         {
           app: { name: "chrome", options: { headless: true } },
-          platforms: ["windows", "mac", "linux"],
-        },
-        {
-          app: { name: "edge" },
           platforms: ["windows", "mac", "linux"],
         },
       ],

--- a/src/tests/findElement.js
+++ b/src/tests/findElement.js
@@ -35,14 +35,27 @@ async function findElement(config, step, driver) {
   }
 
   // Match text
+  // If step.matchText starts and ends with `/`, treat it as a regex
   if (step.matchText) {
     const text = (await element.getText()) || (await element.getValue());
-    if (text !== step.matchText) {
-      result.status = "FAIL";
-      result.description = `Element text (${text}) didn't equal match text (${step.matchText}).`;
-      return result;
+    if (step.matchText.startsWith("/") && step.matchText.endsWith("/")) {
+      const regex = new RegExp(step.matchText.slice(1, -1));
+      if (regex.test(text)) {
+        result.description = result.description + " Matched regex.";
+      } else {
+        result.status = "FAIL";
+        result.description = `Element text (${text}) didn't match regex (${step.matchText}).`;
+        return result;
+      }
+    } else {
+      if (text === step.matchText) {
+        result.description = result.description + " Matched text.";
+      } else {
+        result.status = "FAIL";
+        result.description = `Element text (${text}) didn't equal match text (${step.matchText}).`;
+        return result;
+      }
     }
-    result.description = result.description + " Matched text.";
   }
 
   // Move to element

--- a/test/artifacts/matchText_regex.spec.json
+++ b/test/artifacts/matchText_regex.spec.json
@@ -1,0 +1,28 @@
+{
+  "id": "matchTextRegex",
+  "tests": [
+    {
+      "steps": [
+        {
+          "action": "goTo",
+          "url": "https://doc-detective.com/reference/schemas/config.html"
+        },
+        {
+          "action": "find",
+          "selector": "h2#description",
+          "matchText": "Description"
+        },
+        {
+          "action": "find",
+          "selector": "h2#description",
+          "matchText": "/^Description$/"
+        },
+        {
+          "action": "find",
+          "selector": "h2#description",
+          "matchText": "/^D.*?n/"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Allows regex matching in the `find` action's `matchText` field when the value starts and ends with `/`. Mirrors the formatting and behavior of `runShell`'s `output` matching.