### PR TITLE
Save and diff results of runShell and httpRequest actions #48

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -33,7 +33,7 @@ async function main() {
     recursive: true,
     logLevel: "debug",
     runTests: {
-      input: "./test/artifacts/runShell.spec.json",
+      input: "./test/artifacts/httpRequest.spec.json",
       output: ".",
       setup: "",
       cleanup: "",

--- a/dev/index.js
+++ b/dev/index.js
@@ -33,7 +33,7 @@ async function main() {
     recursive: true,
     logLevel: "debug",
     runTests: {
-      input: "./test/artifacts/httpRequest.spec.json",
+      input: "./test/artifacts/runShell.spec.json",
       output: ".",
       setup: "",
       cleanup: "",

--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -1,6 +1,9 @@
 const { validate } = require("doc-detective-common");
 const axios = require("axios");
 const jq = require("node-jq");
+const fs = require("fs");
+const path = require("path");
+const { log } = require("../utils");
 
 exports.httpRequest = httpRequest;
 
@@ -107,6 +110,61 @@ async function httpRequest(config, step) {
           ` Couldn't set '${variable.name}' environment variable. The jq filter (${variable.jqFilter}) returned a null result.`;
       }
     }
+
+  // Check if command output is saved to a file
+  if (step.savePath) {
+    const dir =
+      step.directory ||
+      config.runTests?.mediaDirectory ||
+      config.runTests?.output ||
+      config.output;
+    // If `dir` doesn't exist, create it
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    // Set filePath
+    const filePath = path.resolve(dir, step.savePath);
+    log(config,"debug", `Saving output to file: ${filePath}`)
+
+    // Check if file already exists
+    if (!fs.existsSync(filePath)) {
+      // Doesn't exist, save output to file
+      fs.writeFileSync(filePath, JSON.stringify(response.data, null, 2))
+    } else {
+      if (step.overwrite == "false") {
+        // File already exists
+        result.description =
+          result.description + ` Didn't save output. File already exists.`;
+      }
+
+      // Read existing file
+      const existingFile = fs.readFileSync(filePath, "utf8");
+
+      // Calculate percentage diff between existing file content and command output content, not length
+      const percentDiff = calculatePercentageDifference(
+        existingFile,
+        JSON.stringify(response.data, null, 2)
+      );
+      log(config,"debug", `Percentage difference: ${percentDiff}%`);
+
+      if (percentDiff > step.maxVariation) {
+        if (step.overwrite == "byVariation") {
+          // Overwrite file
+          fs.writeFileSync(filePath, JSON.stringify(response.data, null, 2));
+        }
+        result.status = "FAIL";
+        result.description =
+          result.description +
+          ` The percentage difference between the existing file content and command output content (${percentDiff}%) is greater than the max accepted variation (${step.maxVariation}%).`;
+        return result;
+      }
+
+      if (step.overwrite == "true") {
+        // Overwrite file
+        fs.writeFileSync(filePath, JSON.stringify(response.data, null, 2));
+      }
+    }
+  }
 
   result.description = result.description.trim();
   return result;
@@ -246,4 +304,38 @@ function objectExistsInObject(expected, actual) {
   });
   result = { status, description };
   return { result };
+}
+
+function calculatePercentageDifference(text1, text2) {
+  const distance = llevenshteinDistance(text1, text2);
+  const maxLength = Math.max(text1.length, text2.length);
+  const percentageDiff = (distance / maxLength) * 100;
+  return percentageDiff.toFixed(2); // Returns the percentage difference as a string with two decimal places
+}
+
+function llevenshteinDistance(s, t) {
+  if (!s.length) return t.length;
+  if (!t.length) return s.length;
+
+  const arr = [];
+
+  for (let i = 0; i <= t.length; i++) {
+    arr[i] = [i];
+  }
+
+  for (let j = 0; j <= s.length; j++) {
+    arr[0][j] = j;
+  }
+
+  for (let i = 1; i <= t.length; i++) {
+    for (let j = 1; j <= s.length; j++) {
+      arr[i][j] = Math.min(
+        arr[i - 1][j] + 1, // deletion
+        arr[i][j - 1] + 1, // insertion
+        arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1) // substitution
+      );
+    }
+  }
+
+  return arr[t.length][s.length];
 }

--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -3,7 +3,7 @@ const axios = require("axios");
 const jq = require("node-jq");
 const fs = require("fs");
 const path = require("path");
-const { log } = require("../utils");
+const { log, calculatePercentageDifference } = require("../utils");
 
 exports.httpRequest = httpRequest;
 
@@ -304,38 +304,4 @@ function objectExistsInObject(expected, actual) {
   });
   result = { status, description };
   return { result };
-}
-
-function calculatePercentageDifference(text1, text2) {
-  const distance = llevenshteinDistance(text1, text2);
-  const maxLength = Math.max(text1.length, text2.length);
-  const percentageDiff = (distance / maxLength) * 100;
-  return percentageDiff.toFixed(2); // Returns the percentage difference as a string with two decimal places
-}
-
-function llevenshteinDistance(s, t) {
-  if (!s.length) return t.length;
-  if (!t.length) return s.length;
-
-  const arr = [];
-
-  for (let i = 0; i <= t.length; i++) {
-    arr[i] = [i];
-  }
-
-  for (let j = 0; j <= s.length; j++) {
-    arr[0][j] = j;
-  }
-
-  for (let i = 1; i <= t.length; i++) {
-    for (let j = 1; j <= s.length; j++) {
-      arr[i][j] = Math.min(
-        arr[i - 1][j] + 1, // deletion
-        arr[i][j - 1] + 1, // insertion
-        arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1) // substitution
-      );
-    }
-  }
-
-  return arr[t.length][s.length];
 }

--- a/src/tests/runShell.js
+++ b/src/tests/runShell.js
@@ -1,5 +1,7 @@
 const { validate } = require("doc-detective-common");
-const { spawnCommand } = require("../utils");
+const { spawnCommand, log } = require("../utils");
+const fs = require("fs");
+const path = require("path");
 
 exports.runShell = runShell;
 
@@ -88,5 +90,94 @@ async function runShell(config, step) {
     }
   }
 
+  // Check if command output is saved to a file
+  if (step.savePath) {
+    const dir =
+      step.directory ||
+      config.runTests?.mediaDirectory ||
+      config.runTests?.output ||
+      config.output;
+    // If `dir` doesn't exist, create it
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    // Set filePath
+    const filePath = path.resolve(dir, step.savePath);
+    log(config,"debug", `Saving output to file: ${filePath}`)
+
+    // Check if file already exists
+    if (!fs.existsSync(filePath)) {
+      // Doesn't exist, save output to file
+      fs.writeFileSync(filePath, result.stdout)
+    } else {
+      if (step.overwrite == "false") {
+        // File already exists
+        result.description =
+          result.description + ` Didn't save output. File already exists.`;
+      }
+
+      // Read existing file
+      const existingFile = fs.readFileSync(filePath, "utf8");
+
+      // Calculate percentage diff between existing file content and command output content, not length
+      const percentDiff = calculatePercentageDifference(
+        existingFile,
+        result.stdout
+      );
+      log(config,"debug", `Percentage difference: ${percentDiff}%`);
+
+      if (percentDiff > step.maxVariation) {
+        if (step.overwrite == "byVariation") {
+          // Overwrite file
+          fs.writeFileSync(filePath, result.stdout);
+        }
+        result.status = "FAIL";
+        result.description =
+          result.description +
+          ` The percentage difference between the existing file content and command output content (${percentDiff}%) is greater than the max accepted variation (${step.maxVariation}%).`;
+        return result;
+      }
+
+      if (step.overwrite == "true") {
+        // Overwrite file
+        fs.writeFileSync(filePath, result.stdout);
+      }
+    }
+  }
+
   return result;
+}
+
+function calculatePercentageDifference(text1, text2) {
+  const distance = llevenshteinDistance(text1, text2);
+  const maxLength = Math.max(text1.length, text2.length);
+  const percentageDiff = (distance / maxLength) * 100;
+  return percentageDiff.toFixed(2); // Returns the percentage difference as a string with two decimal places
+}
+
+function llevenshteinDistance(s, t) {
+  if (!s.length) return t.length;
+  if (!t.length) return s.length;
+
+  const arr = [];
+
+  for (let i = 0; i <= t.length; i++) {
+    arr[i] = [i];
+  }
+
+  for (let j = 0; j <= s.length; j++) {
+    arr[0][j] = j;
+  }
+
+  for (let i = 1; i <= t.length; i++) {
+    for (let j = 1; j <= s.length; j++) {
+      arr[i][j] = Math.min(
+        arr[i - 1][j] + 1, // deletion
+        arr[i][j - 1] + 1, // insertion
+        arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1) // substitution
+      );
+    }
+  }
+
+  return arr[t.length][s.length];
 }

--- a/src/tests/runShell.js
+++ b/src/tests/runShell.js
@@ -1,5 +1,5 @@
 const { validate } = require("doc-detective-common");
-const { spawnCommand, log } = require("../utils");
+const { spawnCommand, log, calculatePercentageDifference } = require("../utils");
 const fs = require("fs");
 const path = require("path");
 
@@ -146,38 +146,4 @@ async function runShell(config, step) {
   }
 
   return result;
-}
-
-function calculatePercentageDifference(text1, text2) {
-  const distance = llevenshteinDistance(text1, text2);
-  const maxLength = Math.max(text1.length, text2.length);
-  const percentageDiff = (distance / maxLength) * 100;
-  return percentageDiff.toFixed(2); // Returns the percentage difference as a string with two decimal places
-}
-
-function llevenshteinDistance(s, t) {
-  if (!s.length) return t.length;
-  if (!t.length) return s.length;
-
-  const arr = [];
-
-  for (let i = 0; i <= t.length; i++) {
-    arr[i] = [i];
-  }
-
-  for (let j = 0; j <= s.length; j++) {
-    arr[0][j] = j;
-  }
-
-  for (let i = 1; i <= t.length; i++) {
-    for (let j = 1; j <= s.length; j++) {
-      arr[i][j] = Math.min(
-        arr[i - 1][j] + 1, // deletion
-        arr[i][j - 1] + 1, // insertion
-        arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1) // substitution
-      );
-    }
-  }
-
-  return arr[t.length][s.length];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,7 @@ exports.loadEnvs = loadEnvs;
 exports.spawnCommand = spawnCommand;
 exports.inContainer = inContainer;
 exports.cleanTemp = cleanTemp;
+exports.calculatePercentageDifference = calculatePercentageDifference;
 
 // Delete all contents of doc-detective temp directory
 function cleanTemp() {
@@ -662,4 +663,38 @@ async function inContainer() {
     if (result.exitCode === 0) return true;
   }
   return false;
+}
+
+function calculatePercentageDifference(text1, text2) {
+  const distance = llevenshteinDistance(text1, text2);
+  const maxLength = Math.max(text1.length, text2.length);
+  const percentageDiff = (distance / maxLength) * 100;
+  return percentageDiff.toFixed(2); // Returns the percentage difference as a string with two decimal places
+}
+
+function llevenshteinDistance(s, t) {
+  if (!s.length) return t.length;
+  if (!t.length) return s.length;
+
+  const arr = [];
+
+  for (let i = 0; i <= t.length; i++) {
+    arr[i] = [i];
+  }
+
+  for (let j = 0; j <= s.length; j++) {
+    arr[0][j] = j;
+  }
+
+  for (let i = 1; i <= t.length; i++) {
+    for (let j = 1; j <= s.length; j++) {
+      arr[i][j] = Math.min(
+        arr[i - 1][j] + 1, // deletion
+        arr[i][j - 1] + 1, // insertion
+        arr[i - 1][j - 1] + (s[j - 1] === t[i - 1] ? 0 : 1) // substitution
+      );
+    }
+  }
+
+  return arr[t.length][s.length];
 }

--- a/test/artifacts/httpRequest.spec.json
+++ b/test/artifacts/httpRequest.spec.json
@@ -48,7 +48,10 @@
               "last_name": "Bluth"
             }
           },
-          "statusCodes": [200, 201]
+          "statusCodes": [200, 201],
+          "savePath": "response.json",
+          "maxVariation": 0,
+          "overwrite": "byVariation"
         }
       ]
     }

--- a/test/artifacts/runShell.spec.json
+++ b/test/artifacts/runShell.spec.json
@@ -30,6 +30,21 @@
           "action": "runShell",
           "command": "echo timeout",
           "timeout": 2000
+        },
+        {
+          "description": "Testing exit code.",
+          "action": "runShell",
+          "command": "exit",
+          "args": ["1"],
+          "exitCodes": [1]
+        },
+        {
+          "description": "Testing savePath.",
+          "action": "runShell",
+          "command": "echo hello",
+          "savePath": "test.txt",
+          "maxVariation": 0,
+          "overwrite": "byVariation"
         }
       ]
     }


### PR DESCRIPTION
Mirroring existing saveScreenshot behaviors, DD can now save, compare, and overwite outputs from runShell commands and response body data from httpRequests.