### PR TITLE
Set enviroment variables from found element text

### DIFF
--- a/src/tests/findElement.js
+++ b/src/tests/findElement.js
@@ -46,14 +46,16 @@ async function findElement(config, step, driver) {
   }
 
   // Set environment variables from command output
-  for (const variable of step.setVariables) {
-    const regex = new RegExp(variable.regex);
-    const matchText = text.match(regex);
-    if (matchText) {
-      process.env[variable.name] = matchText[0];
-    } else {
-      result.status = "FAIL";
-      result.description = `Couldn't set '${variable.name}' environment variable. The regex (${variable.regex}) wasn't found in the element text (${text}).`;
+  if (step.setVariables) {
+    for (const variable of step.setVariables) {
+      const regex = new RegExp(variable.regex);
+      const matchText = text.match(regex);
+      if (matchText) {
+        process.env[variable.name] = matchText[0];
+      } else {
+        result.status = "FAIL";
+        result.description = `Couldn't set '${variable.name}' environment variable. The regex (${variable.regex}) wasn't found in the element text (${text}).`;
+      }
     }
   }
 

--- a/test/artifacts/find.spec.json
+++ b/test/artifacts/find.spec.json
@@ -1,0 +1,30 @@
+{
+  "tests": [
+    {
+      "id": "Set env variable from element text",
+      "steps": [
+        {
+          "action": "goTo",
+          "url": "https://doc-detective.com/reference/schemas/config.html"
+        },
+        {
+          "description": "Set DESCRIPTION variable to the text of the element with id 'description'",
+          "action": "find",
+          "selector": "h2#description",
+          "setVariables": [
+            {
+              "name": "DESCRIPTION",
+              "regex": ".*"
+            }
+          ]
+        },
+        {
+          "description": "Print and validate the value of the DESCRIPTION variable.",
+          "action": "runShell",
+          "command": "echo $DESCRIPTION",
+          "output": "Description"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Mirroring setting environment variables from runShell output and httpRequest responses, find action can now set environment variables from the text of found elements using regex matching.