### PR TITLE
Strict response data matching for httpRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.7",
         "appium-safari-driver": "^3.5.16",
         "axios": "^1.7.2",
-        "doc-detective-common": "1.18.0-dev.2",
+        "doc-detective-common": "1.18.0-dev.3",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.6.0",
         "geckodriver": "^4.4.1",
@@ -13399,9 +13399,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.18.0-dev.2",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.18.0-dev.2.tgz",
-      "integrity": "sha512-4O3ZdB81bviq4wUkyOGTzWsBRSkX5lK2KOZ1t9Xq35rCLgaM9/oWO6Prqakmm2asMdiTJG31CpXQne1jcsX67Q==",
+      "version": "1.18.0-dev.3",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.18.0-dev.3.tgz",
+      "integrity": "sha512-9umjqrDQiVV2RdU346b71kMLC430w+dX0jM0VQXLqmZ84Bodr1+od2gD4jmBd+/FRGNQnu+KB0YgHmkUPaB2qA==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
         "ajv": "^8.16.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.7",
     "appium-safari-driver": "^3.5.16",
     "axios": "^1.7.2",
-    "doc-detective-common": "1.18.0-dev.2",
+    "doc-detective-common": "1.18.0-dev.3",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.6.0",
     "geckodriver": "^4.4.1",

--- a/src/tests.js
+++ b/src/tests.js
@@ -365,7 +365,7 @@ async function runSpecs(config, specs) {
         for (let step of test.steps) {
           // Set step id if not defined
           if (!step.id) step.id = `${uuid.v4()}`;
-          log(config, "debug", `STEP: ${step.id}`);
+          log(config, "debug", `STEP:\n${step.id}`);
 
           const stepResult = await runStep(config, context, step, driver);
           log(

--- a/src/tests.js
+++ b/src/tests.js
@@ -365,7 +365,7 @@ async function runSpecs(config, specs) {
         for (let step of test.steps) {
           // Set step id if not defined
           if (!step.id) step.id = `${uuid.v4()}`;
-          log(config, "debug", `STEP:\n${step.id}`);
+          log(config, "debug", `STEP:\n${step}`);
 
           const stepResult = await runStep(config, context, step, driver);
           log(

--- a/src/tests.js
+++ b/src/tests.js
@@ -365,7 +365,7 @@ async function runSpecs(config, specs) {
         for (let step of test.steps) {
           // Set step id if not defined
           if (!step.id) step.id = `${uuid.v4()}`;
-          log(config, "debug", `STEP:\n${step}`);
+          log(config, "debug", `STEP:\n${JSON.stringify(step,null,2)}`);
 
           const stepResult = await runStep(config, context, step, driver);
           log(

--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -34,6 +34,7 @@ async function httpRequest(config, step) {
   // Perform request
   const response = await axios(request)
     .then((response) => {
+      result.actualResponseData = response.data;
       return response;
     })
     .catch((error) => {
@@ -59,8 +60,19 @@ async function httpRequest(config, step) {
   }
 
   // Compare response.data and responseData
+  if (!step.allowAdditionalFields) {
+    // Do a deep comparison
+    let dataComparison = objectExistsInObject(response.data, step.responseData);
+    if (dataComparison.result.status === "FAIL") {
+      result.status = "FAIL";
+      result.description =
+        result.description + " Response contained unexpected fields.";
+      return result;
+    }
+  }
+
   if (JSON.stringify(step.responseData) != "{}") {
-    dataComparison = objectExistsInObject(step.responseData, response.data);
+    let dataComparison = objectExistsInObject(step.responseData, response.data);
     if (dataComparison.result.status === "PASS") {
       if (result.status != "FAIL") result.status = "PASS";
       result.description =

--- a/test/artifacts/httpRequest.spec.json
+++ b/test/artifacts/httpRequest.spec.json
@@ -41,7 +41,7 @@
           "action": "httpRequest",
           "url": "https://reqres.in/api/users/$ID",
           "method": "get",
-          "timeout": 100,
+          "timeout": 1000,
           "responseData": {
             "data": {
               "first_name": "George",

--- a/test/artifacts/httpRequest.spec.json
+++ b/test/artifacts/httpRequest.spec.json
@@ -54,6 +54,32 @@
           "overwrite": "byVariation"
         }
       ]
+    },
+    {
+      "id": "Strict response data test",
+      "description": "Set `allowAdditionalFields` to `false` to ensure that the response data is strictly matched.",
+      "steps": [
+        {
+          "action": "httpRequest",
+          "url": "https://reqres.in/api/users/1",
+          "method": "get",
+          "timeout": 100,
+          "responseData": {
+            "data": {
+              "id": 1,
+              "email": "george.bluth@reqres.in",
+              "first_name": "George",
+              "last_name": "Bluth",
+              "avatar": "https://reqres.in/img/faces/1-image.jpg"
+            },
+            "support": {
+              "url": "https://reqres.in/#support-heading",
+              "text": "To keep ReqRes free, contributions towards server costs are appreciated!"
+            }
+          },
+          "allowAdditionalFields": false
+        }
+      ]
     }
   ]
 }

--- a/test/artifacts/runShell.spec.json
+++ b/test/artifacts/runShell.spec.json
@@ -32,13 +32,6 @@
           "timeout": 2000
         },
         {
-          "description": "Testing exit code.",
-          "action": "runShell",
-          "command": "exit",
-          "args": ["1"],
-          "exitCodes": [1]
-        },
-        {
           "description": "Testing savePath.",
           "action": "runShell",
           "command": "echo hello",


### PR DESCRIPTION
If allowAdditionalFields is set to false, the step fails if the response contains fields that aren't specified in responseData. Defaults to true.