### PR TITLE
`workingDirectory` for `runShell`

### DIFF
--- a/dev/index.js
+++ b/dev/index.js
@@ -34,7 +34,7 @@ async function main() {
     logLevel: "debug",
     relativePathBase: "file",
     runTests: {
-      input: "./dev/dev.spec.json",
+      input: "./dev/runShell.spec.json",
       output: ".",
       setup: "",
       cleanup: "",

--- a/dev/runShell.spec.json
+++ b/dev/runShell.spec.json
@@ -1,27 +1,11 @@
 {
-  "id": "setup",
   "tests": [
     {
       "steps": [
         {
           "action": "runShell",
-          "command": "echo",
-          "args": ["setup"],
-          "exitCodes": [0],
-          "output": "/.*?/",
-          "setVariables": [
-            {
-              "name": "TEST",
-              "regex": ".*"
-            }
-          ]
-        },
-        {
-          "action": "runShell",
-          "command": "echo",
-          "args": ["$TEST"],
-          "exitCodes": [0],
-          "output": "setup"
+          "command": "dir",
+          "workingDirectory": "."
         }
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doc-detective-core",
-  "version": "2.16.0-dev.0",
+  "version": "2.16.0-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doc-detective-core",
-      "version": "2.16.0-dev.0",
+      "version": "2.16.0-dev.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "appium-geckodriver": "^1.3.8",
         "appium-safari-driver": "^3.5.16",
         "axios": "^1.7.2",
-        "doc-detective-common": "^1.19.1-dev.0",
+        "doc-detective-common": "^1.19.1-dev.1",
         "dotenv": "^16.4.5",
         "edgedriver": "^5.6.0",
         "geckodriver": "^4.4.2",
@@ -12783,9 +12783,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.19.1-dev.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.19.1-dev.0.tgz",
-      "integrity": "sha512-mF7QQIOui5sOxLOfGPRd/CrnK1hNqTQpxG8zzfZtsXzy0+vxqYNEhhzyPYSNwoPsRgp7ZWXh1yLLbxcdLB2i0Q==",
+      "version": "1.19.1-dev.1",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.19.1-dev.1.tgz",
+      "integrity": "sha512-rRdS4X4fU3uY2veunbnmsUDHSXE0WGTsQmc0T54lxeMhQxi6HAdZ/XYUB3d0EJAHs1e6GWQ8grwJJTFVVoZxKQ==",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.6.4",
         "ajv": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-detective-core",
-  "version": "2.16.0-dev.0",
+  "version": "2.16.0-dev.1",
   "description": "The doc testing framework.",
   "main": "src/index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "appium-geckodriver": "^1.3.8",
     "appium-safari-driver": "^3.5.16",
     "axios": "^1.7.2",
-    "doc-detective-common": "^1.19.1-dev.0",
+    "doc-detective-common": "^1.19.1-dev.1",
     "dotenv": "^16.4.5",
     "edgedriver": "^5.6.0",
     "geckodriver": "^4.4.2",

--- a/src/tests/runShell.js
+++ b/src/tests/runShell.js
@@ -1,4 +1,4 @@
-const { validate } = require("doc-detective-common");
+const { validate, resolvePaths } = require("doc-detective-common");
 const { spawnCommand, log, calculatePercentageDifference } = require("../utils");
 const fs = require("fs");
 const path = require("path");
@@ -26,7 +26,9 @@ async function runShell(config, step) {
 
   // Execute command
   const timeout = step.timeout;
-  const commandPromise = spawnCommand(step.command, step.args);
+  const options = {};
+  if (step.workingDirectory) options.cwd = step.workingDirectory;
+  const commandPromise = spawnCommand(step.command, step.args, options);
   let timeoutId;
   const timeoutPromise = new Promise((resolve, reject) => {
     timeoutId = setTimeout(() => {


### PR DESCRIPTION
`runShell` actions now support specifying the `workingDirectory` in which to run `command`. If the specified directory doesn't exist, falls back to the the directory Doc Detective was run in. As with other paths, `workingDirectory` is sensitive to the config's relativePathBase property, letting you specify whether the directory is relative to the current working directory or the file in which the directory is specified.