### PR TITLE
Load environment variables from OpenAPI definitions and fix error handling

### DIFF
--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -136,7 +136,7 @@ async function httpRequest(config, step, openApiDefinitions = []) {
 
   // Make sure there's a protocol
   if (step.url && !step.url.includes("://")) step.url = "https://" + step.url;
-
+  
   // Load environment variables
   step = await loadEnvs(step);
 
@@ -190,12 +190,14 @@ async function httpRequest(config, step, openApiDefinitions = []) {
     // Perform request
     response = await axios(request)
       .then((response) => {
-        result.actualResponseData = response.data;
         return response;
       })
       .catch((error) => {
         return { error };
       });
+    if (response.error) 
+      response = response.error.response;
+    result.actualResponseData = response.data;
   } else {
     // Mock response
     if (
@@ -209,14 +211,6 @@ async function httpRequest(config, step, openApiDefinitions = []) {
     result.actualResponseData = response.data;
     response.status = step.statusCodes[0];
     response.headers = step.responseHeaders;
-  }
-
-  // If request returned an error
-  if (response.error) {
-    result.status = "FAIL";
-    result.actualResponseData = response.error.response?.data;
-    result.description = `Error: ${JSON.stringify(response.error.message)}`;
-    return result;
   }
 
   // Compare status codes

--- a/src/tests/httpRequest.js
+++ b/src/tests/httpRequest.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const Ajv = require("ajv");
 const { getOperation, loadDescription } = require("../openapi");
-const { log, calculatePercentageDifference } = require("../utils");
+const { log, calculatePercentageDifference, loadEnvs } = require("../utils");
 
 exports.httpRequest = httpRequest;
 
@@ -136,6 +136,9 @@ async function httpRequest(config, step, openApiDefinitions = []) {
 
   // Make sure there's a protocol
   if (step.url && !step.url.includes("://")) step.url = "https://" + step.url;
+
+  // Load environment variables
+  step = await loadEnvs(step);
 
   // Validate step payload
   isValidStep = validate("httpRequest_v2", step);


### PR DESCRIPTION
This pull request introduces functionality to load environment variables directly from OpenAPI definitions, enhancing the flexibility of HTTP requests. Additionally, it improves error handling for HTTP requests by ensuring that error responses are correctly processed and logged, providing clearer feedback on request failures. This addresses issues with negative test cases for errored HTTP requests, ensuring more robust testing and validation.