### PR TITLE
Add onStepFail option and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "appium-geckodriver": "^1.4.0",
         "appium-safari-driver": "^3.5.18",
         "axios": "^1.7.7",
-        "doc-detective-common": "^1.21.1-dev.0",
+        "doc-detective-common": "^1.21.1-dev.2",
         "dotenv": "^16.4.5",
         "edgedriver": "^6.1.1",
         "geckodriver": "^5.0.0",
@@ -32,7 +32,7 @@
         "sharp": "^0.33.5",
         "tree-kill": "^1.2.2",
         "uuid": "^11.0.3",
-        "webdriverio": "^9.2.12"
+        "webdriverio": "^9.2.14"
       },
       "devDependencies": {
         "depcheck": "^1.4.7",
@@ -13314,9 +13314,9 @@
       }
     },
     "node_modules/doc-detective-common": {
-      "version": "1.21.1-dev.0",
-      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.21.1-dev.0.tgz",
-      "integrity": "sha512-nmfGQqOW1R68d0wsVV0/05xRh+/Tf0S89KMa8XKTpSkk6LHk/mMzb9cCuPmYOj3ODOzjpcsKxDK7KAVS5orRGQ==",
+      "version": "1.21.1-dev.2",
+      "resolved": "https://registry.npmjs.org/doc-detective-common/-/doc-detective-common-1.21.1-dev.2.tgz",
+      "integrity": "sha512-wD1vCj4WEAGm/is3GNXTrneKf9zr4gFHmGbevLS//ouc0OcXRovCRZqp4cuO8+F0iNPfzlrctI+4cC74J5vjKw==",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.2",
@@ -18008,9 +18008,9 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.2.12.tgz",
-      "integrity": "sha512-XtptP5mrubvr6s1GrtPk1DqdfcMvnaYqZCTfWT0EIebFFnQSz9sc0c9qn553zoNB6Xfe6+kyTRh9Tyj7AFIrEg==",
+      "version": "9.2.14",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.2.14.tgz",
+      "integrity": "sha512-85yEbwN3MwdrGzKZoGkLUf1J5cpfnc7knL4u/Y6XWd0gGwYjv60I5ZPsgSnXzNXAkq2kmtkammf1AM3ihqFM3A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "appium-geckodriver": "^1.4.0",
     "appium-safari-driver": "^3.5.18",
     "axios": "^1.7.7",
-    "doc-detective-common": "^1.21.1-dev.0",
+    "doc-detective-common": "^1.21.1-dev.2",
     "dotenv": "^16.4.5",
     "edgedriver": "^6.1.1",
     "geckodriver": "^5.0.0",
@@ -49,7 +49,7 @@
     "sharp": "^0.33.5",
     "tree-kill": "^1.2.2",
     "uuid": "^11.0.3",
-    "webdriverio": "^9.2.12"
+    "webdriverio": "^9.2.14"
   },
   "optionalDependencies": {
     "@ffmpeg-installer/darwin-arm64": "4.1.5",

--- a/src/arazzo.js
+++ b/src/arazzo.js
@@ -11,8 +11,9 @@ function workflowToTest(arazzoDescription, workflowId, inputs) {
     id: arazzoDescription.info.title || `${uuid()}`,
     description:
       arazzoDescription.info.description || arazzoDescription.info.summary,
-    steps: [],
     openApi: [],
+    onStepFail: "stop",
+    steps: [],
   };
 
   arazzoDescription.sourceDescriptions.forEach((source) => {

--- a/src/tests.js
+++ b/src/tests.js
@@ -461,6 +461,12 @@ async function runSpecs(config, specs) {
             `RESULT: ${stepResult.status}, ${stepResult.description}`
           );
 
+          // If onStepFail is set to "stop" and step fails, stop the test
+          if (config?.runTests?.onStepFail === "stop" && stepResult.status === "FAIL") {
+            log(config, "error", `Stopping test. Step failed: ${stepResult.description}`);
+            break;
+          }
+
           stepResult.result = stepResult.status;
           stepResult.resultDescription = stepResult.description;
           delete stepResult.status;


### PR DESCRIPTION
Introduce an `onStepFail` option to control test execution flow during tests. Update dependencies to their latest versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced error handling in test execution, allowing tests to halt immediately upon a step failure.
	- Added a new property `onStepFail` to the test configuration, enhancing control over workflow execution.

- **Bug Fixes**
	- Improved handling of unsupported step types and operation path references during workflow translation.

- **Chores**
	- Updated dependency versions for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->